### PR TITLE
Add support for detecting and parsing Julids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "julid-rs"
+version = "1.6.1803398874989"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45d220e514a000f51e153655b164326d07e0bceb731345ee27b69f2fa843ea9b"
+dependencies = [
+ "chrono",
+ "rand 0.8.5",
+ "uuid",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,11 +1471,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
  "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1495,6 +1508,7 @@ dependencies = [
  "hex",
  "imei",
  "isbn",
+ "julid-rs",
  "mac_address",
  "resize-slice",
  "scru128",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,4 @@ isbn = "0.4.0"
 imei = "=1.1.1"
 h3ron = "0.18.0"
 tsid = "0.3.4"
+julid-rs = { version = "1.6.1803398874989", default-features = false, features = ["chrono", "uuid"] }

--- a/src/formats/julid.rs
+++ b/src/formats/julid.rs
@@ -1,0 +1,52 @@
+use julid::Julid;
+use std::fmt::Write;
+use uuid::Uuid;
+
+use crate::schema::{Args, IDInfo};
+
+pub fn parse_julid(args: &Args) -> Option<IDInfo> {
+    let mut id_type = "Julid";
+    let mut parsed = "from Crockford's base32";
+    let julid = match Julid::from_str(&args.id) {
+        Ok(value) => value,
+        Err(_) => {
+            id_type = "Julid wrapped in UUID";
+            parsed = "from hex";
+            Julid::from_uuid(Uuid::try_parse(&args.id).ok()?).ok()?
+        }
+    };
+
+    // there's not a bulletproof way to detect a Julid from a ULID, so we just say if there's any
+    // bits set in the high end of the counter section it's probably a regular ULID
+    if julid.counter().leading_zeros() < 8 {
+        return None;
+    }
+
+    // UUIDv7
+    let uuid = julid.as_uuid();
+
+    // julid timestamp is in milliseconds, but we want seconds
+    let timestamp = (julid.timestamp() as f64) / 1000.0;
+    let timestamp = format!("{:.3}", timestamp);
+    let datetime = julid.created_at().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+
+    Some(IDInfo {
+        id_type: id_type.to_string(),
+        standard: julid.to_string(),
+        integer: Some(u128::from_be_bytes(julid.as_bytes())),
+        uuid_wrap: Some(uuid.to_string()),
+        parsed: Some(parsed.to_string()),
+        size: 128,
+        entropy: 64,
+        datetime: Some(datetime),
+        timestamp: Some(timestamp.to_string()),
+        sequence: Some(julid.counter() as u128),
+        hex: Some(hex::encode(julid.as_bytes())),
+        bits: Some(julid.as_bytes().iter().fold(String::new(), |mut output, c| {
+            let _ = write!(output, "{c:08b}");
+            output
+        })),
+        color_map: Some("33333333333333333333333333333333333333333333333366666666666666662222222222222222222222222222222222222222222222222222222222222222".to_string()),
+        ..Default::default()
+    })
+}

--- a/src/formats/julid.rs
+++ b/src/formats/julid.rs
@@ -2,7 +2,7 @@ use julid::Julid;
 use std::fmt::Write;
 use uuid::Uuid;
 
-use crate::schema::{Args, IDInfo};
+use crate::schema::{Args, IDInfo, IdFormat};
 
 pub fn parse_julid(args: &Args) -> Option<IDInfo> {
     let mut id_type = "Julid";
@@ -18,7 +18,7 @@ pub fn parse_julid(args: &Args) -> Option<IDInfo> {
 
     // there's not a bulletproof way to detect a Julid from a ULID, so we just say if there's any
     // bits set in the high end of the counter section it's probably a regular ULID
-    if julid.counter().leading_zeros() < 8 {
+    if julid.counter().leading_zeros() < 8 && args.force != Some(IdFormat::Julid) {
         return None;
     }
 

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -7,6 +7,7 @@ pub mod hash;
 pub mod hashid;
 pub mod ipfs;
 pub mod isbn;
+pub mod julid;
 pub mod ksuid;
 pub mod nanoid;
 pub mod network;

--- a/src/id_format.rs
+++ b/src/id_format.rs
@@ -9,6 +9,7 @@ use crate::formats::hash::parse_hash;
 use crate::formats::hashid::parse_hashid;
 use crate::formats::ipfs::parse_ipfs;
 use crate::formats::isbn::parse_isbn;
+use crate::formats::julid::parse_julid;
 use crate::formats::ksuid::parse_ksuid;
 use crate::formats::nanoid::parse_nanoid;
 use crate::formats::network::{parse_imei, parse_ipv4, parse_ipv6, parse_mac};
@@ -36,13 +37,14 @@ type ParseFunction = fn(&Args) -> Option<IDInfo>;
 
 #[rustfmt::skip]
 #[allow(dead_code)]
-pub const ALL_PARSERS: [ParseFunction; 39] = [
+pub const ALL_PARSERS: [ParseFunction; 40] = [
     parse_uuid,
     parse_base64_uuid,
     parse_uuid25,
     parse_short_uuid,
     parse_uuid_integer,
     parse_ulid,
+    parse_julid,
     parse_upid,
     parse_objectid,
     parse_ksuid,
@@ -110,7 +112,7 @@ pub fn auto_detect(args: &Args) -> Option<IDInfo> {
             36 => parse_uuid(args),
             32 => pick_first_valid(args, vec![parse_datadog, parse_uuid]),
             27 => pick_first_valid(args, vec![parse_upid, parse_ksuid]),
-            26 => parse_ulid(args),
+            26 => pick_first_valid(args, vec![parse_julid, parse_ulid]),
             25 => pick_first_valid(args, vec![parse_cuid1, parse_scru128]),
             24 => pick_first_valid(args, vec![parse_objectid, parse_puid, parse_base64_uuid]),
             22 => pick_first_valid(args, vec![parse_short_uuid, parse_timeflake_base62, parse_base64_uuid, parse_nuid]),
@@ -157,6 +159,7 @@ pub fn force_format(args: &Args) -> Option<IDInfo> {
         IdFormat::Uuid25 => parse_uuid25(args),
         IdFormat::UuidInt => parse_uuid_integer(args),
         IdFormat::Ulid => parse_ulid(args),
+        IdFormat::Julid => parse_julid(args),
         IdFormat::Upid => parse_upid(args),
         IdFormat::Timeflake => parse_timeflake_any(args),
         IdFormat::Flake => parse_flake(args),
@@ -249,6 +252,7 @@ mod tests {
         _assert("1734971723000000000", "Unix timestamp", "Assuming nanoseconds");
         // Other:
         _assert("01JCXSGZMZQQJ2M93WC0T8KT02", "ULID", "-");
+        _assert("01K3ESSGBY0002QCB9YXT6Q6MN", "Julid", "-");
         _assert("abcd_2adnrb7b6jkyos6xusvmaa", "UPID", "A (default)");
         _assert("6592008029c8c3e4dc76256c", "MongoDB ObjectId", "-");
         _assert("1HCpXwx2EK9oYluWbacgeCnFcLf", "KSUID", "Base62-encoded");

--- a/src/id_format.rs
+++ b/src/id_format.rs
@@ -377,6 +377,11 @@ mod tests {
         _assert("1734971723000000000", IdFormat::UnixNs, "Unix timestamp", "As nanoseconds");
         // Other:
         _assert("01JCXSGZMZQQJ2M93WC0T8KT02", IdFormat::Ulid, "ULID", "-");
+        // force a ULID to be treated as a Julid
+        _assert("01JCXSGZMZQQJ2M93WC0T8KT02", IdFormat::Julid, "Julid", "-");
+        _assert("01K3EWBQW7000EJNJW8G8WNXKA", IdFormat::Julid, "Julid", "-");
+        // force a Julid to be treated as a ULID
+        _assert("01K3EWBQW7000EJNJW8G8WNXKA", IdFormat::Ulid, "ULID", "-");
         _assert("abcd_2adnrb7b6jkyos6xusvmaa", IdFormat::Upid, "UPID", "A (default)");
         _assert("6592008029c8c3e4dc76256c", IdFormat::Mongodb, "MongoDB ObjectId", "-");
         _assert("1HCpXwx2EK9oYluWbacgeCnFcLf", IdFormat::Ksuid, "KSUID", "Base62-encoded");

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -28,6 +28,8 @@ pub enum IdFormat {
     Uuid25,
     /// ULID
     Ulid,
+    /// Julid
+    Julid,
     /// UPID
     Upid,
     /// Timeflake


### PR DESCRIPTION
Adds support for [Julids](https://git.kittencollective.com/nebkor/julid-rs), which are very similar to ULIDs, but contain a monotonic counter between the timestamp and random bits for maintaining sortability when there are multiple ones created in the same millisecond.

This PR is meant to be stacked on top of #2.